### PR TITLE
Add generic API to log different component in same log file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 - Fixes for building in CentOS
 - Fixes for building in MacOS
+- Add generic API to log different component in same log file
 
 ## [1.0.0] - 2017-10-11
 ### Added

--- a/src/cimplog-rdk-logger.c
+++ b/src/cimplog-rdk-logger.c
@@ -83,9 +83,13 @@ const char *rdk_logger_module_fetch(void)
     return NULL;
 }
 
+/*
+*
+* API to log different component logs in a same log file
+*/
+
 void __cimplog_generic(const char *rdk_logger_module, const char *module, int level, const char *msg, ...)
 {
-    
     static int init_done = 0;
 
     if( !init_done )

--- a/src/cimplog-rdk-logger.c
+++ b/src/cimplog-rdk-logger.c
@@ -83,3 +83,54 @@ const char *rdk_logger_module_fetch(void)
     return NULL;
 }
 
+void __cimplog_generic(const char *rdk_logger_module, const char *module, int level, const char *msg, ...)
+{
+    
+    static int init_done = 0;
+
+    if( !init_done )
+    {
+        rdk_logger_init("/etc/debug.ini");
+        if( NULL == rdk_logger_module )
+        {
+            fprintf(stderr, "\nERROR: RDK Logger not integrated for this module !!!\n");
+            fprintf(stderr, " Provide cimplog method \"const char *rdk_logger_module_fetch(void)\" to get log prints !!\n");
+	    exit(0); // Not using RDKLogger is an Error. Terminate!
+        }
+        init_done = 1;
+    }
+
+    if( NULL == rdk_logger_module )
+    {
+        //if RDK logger module is not defined, simple return - dont print.
+	// used when calling module is not interested in log prints
+        return;
+    }
+
+    //else print to RDK Logger
+    static const rdk_LogLevel _level[] = { RDK_LOG_ERROR, RDK_LOG_INFO, RDK_LOG_DEBUG };
+    va_list arg_ptr;
+    char buf[MAX_BUF_SIZE];
+    int nbytes;
+
+    if (level <= LEVEL_INFO)
+    {
+		va_start(arg_ptr, msg);
+		nbytes = vsnprintf(buf, MAX_BUF_SIZE, msg, arg_ptr);
+		va_end(arg_ptr);
+
+		if( nbytes >=  MAX_BUF_SIZE )	
+		{
+			buf[ MAX_BUF_SIZE - 1 ] = '\0';
+		}
+		else
+		{
+			buf[nbytes] = '\0';
+		}
+		
+		RDK_LOG(_level[0x3 & level], rdk_logger_module, "%s: %s", module, buf);
+    }
+
+    return;
+}
+

--- a/src/cimplog.h
+++ b/src/cimplog.h
@@ -27,9 +27,9 @@
 #define cimplog_info(module, ...)     __cimplog(module, LEVEL_INFO, __VA_ARGS__)
 #define cimplog_debug(module, ...)    __cimplog(module, LEVEL_DEBUG, __VA_ARGS__)
 
-#define onborading_error(rdk_module,module, ...)    __cimplog_generic(rdk_module,module, LEVEL_ERROR, __VA_ARGS__)
-#define onborading_info(rdk_module,module, ...)     __cimplog_generic(rdk_module,module, LEVEL_INFO, __VA_ARGS__)
-#define onborading_debug(rdk_module,module, ...)    __cimplog_generic(rdk_module,module, LEVEL_DEBUG, __VA_ARGS__)
+#define more_error_log(rdk_module,module, ...)    __cimplog_generic(rdk_module,module, LEVEL_ERROR, __VA_ARGS__)
+#define more_info_log(rdk_module,module, ...)     __cimplog_generic(rdk_module,module, LEVEL_INFO, __VA_ARGS__)
+#define more_debug_log(rdk_module,module, ...)    __cimplog_generic(rdk_module,module, LEVEL_DEBUG, __VA_ARGS__)
 
 /**
 * @brief handle log message based on log level

--- a/src/cimplog.h
+++ b/src/cimplog.h
@@ -27,6 +27,10 @@
 #define cimplog_info(module, ...)     __cimplog(module, LEVEL_INFO, __VA_ARGS__)
 #define cimplog_debug(module, ...)    __cimplog(module, LEVEL_DEBUG, __VA_ARGS__)
 
+#define onborading_error(rdk_module,module, ...)    __cimplog_generic(rdk_module,module, LEVEL_ERROR, __VA_ARGS__)
+#define onborading_info(rdk_module,module, ...)     __cimplog_generic(rdk_module,module, LEVEL_INFO, __VA_ARGS__)
+#define onborading_debug(rdk_module,module, ...)    __cimplog_generic(rdk_module,module, LEVEL_DEBUG, __VA_ARGS__)
+
 /**
 * @brief handle log message based on log level
 * 
@@ -35,5 +39,6 @@
 * @param msg message
 */
 void __cimplog(const char *module, int level, const char *msg, ...);
+void __cimplog_generic(const char *rdk_logger_module, const char *module, int level, const char *msg, ...);
 
 #endif


### PR DESCRIPTION
This new **__cimplog_generic** API is to log different component logs in the same log file.
